### PR TITLE
Minor: Console logs differentiate between video and audio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ packages/*/*.wasm
 *.a
 profile.json
 dist
-
+*.tgz
 mandark-history.json
 compiled-code.txt
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Options:
 - `-t, --tier <tier>`: Processing tier (first, business, economy, budget, experimental) [default: "business"]
 - `-s, --save-intermediates`: Save intermediate processing files
 - `-id, --intermediates-dir <path>`: Custom directory for intermediate output
-- `-sc, --screenshot-count <number>`: Number of screenshots to extract [default: 4]
+- `-sc, --screenshot-count <number>`: Number of screenshots to extract for video [default: 4]
 - `-ac, --audio-chunk-minutes <number>`: Length of audio chunks in minutes [default: 10]
 - `-r, --report`: Generate a structured meeting report
 - `-rd, --reports-dir <path>`: Custom directory for report output

--- a/src/run.ts
+++ b/src/run.ts
@@ -311,13 +311,23 @@ async function run() {
     process.exit(1);
   }
 
-  console.log(
-    chalk.green(
-      `Found ${files.length} video file${
-        files.length > 1 ? "s" : ""
-      } to process`
-    )
-  );
+console.log(
+  chalk.green(
+    ((audioCount: number) => {
+      const videoCount = files.length - audioCount;
+      const messages: string[] = [];
+      
+      if (audioCount > 0) {
+        messages.push(`Found ${audioCount} audio file${audioCount > 1 ? "s" : ""} to process`);
+      }
+      if (videoCount > 0) {
+        messages.push(`Found ${videoCount} video file${videoCount > 1 ? "s" : ""} to process`);
+      }
+      
+      return messages.join('\n');
+    })(files.filter(fn => isAudioFile(fn)).length)
+  )
+);
 
   const startTime = Date.now();
   const results = {


### PR DESCRIPTION
This PR updates the console logs to accurately reflect the type of file added

### Importance
This is pretty minor but it fixes some messaging that made me think `offmute` was only for video

### Current situation
Currently, offmute reports all files as video (including audio).

For example, with this audio file:
<img width="366" alt="image" src="https://github.com/user-attachments/assets/8ef949f3-418b-4787-a902-f5f077d33f5b" />

### Fix
The fix correctly reports the audio and video files separately.

For example, both audio and video files:
<img width="281" alt="image" src="https://github.com/user-attachments/assets/16374470-8c7b-4199-a3dc-8bfd664e1c90" />
Just one type of file:
<img width="352" alt="image" src="https://github.com/user-attachments/assets/3baecf9c-80c7-44c9-9773-8de20cc90050" />

### Code commentary
I used an immediately invoked function expression, in order to:
1. Only do the `filter` calculation once and reuse it
2. Not create global variables

I did consider doing this in the `findFiles` function to minimize the `isAudioFile` calls, but decided against it. Iwanted to minimize the surface area I changed, and `isAudioFile` is a relatively light function anyway.

### Testing

I tested `bun run build`, which built fine, and then checked the outcome was as expected (pictured above)

I also checked `npm pack` executed without error, but didn't test the package since it's a pretty minor change